### PR TITLE
Add OnClaimsReceived event

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The authentication provider provided by [EasyAuth][EasyAuth] that were tested we
 First, install the NuGet package [`MaximeRouiller.Azure.AppService.EasyAuth`](https://www.nuget.org/packages/MaximeRouiller.Azure.AppService.EasyAuth/). This can be done either directly from Visual Studio or by running a CLI command like the following.
 
 ```bash
-dotnet add package MaximeRouiller.Azure.AppService.EasyAuth -v 0.1.0-beta82
+dotnet add package MaximeRouiller.Azure.AppService.EasyAuth
 ```
 
 Once the package is installed, make sure that Controllers that require authentication are decorated with the `[Authorize(AuthenticationSchemes = "EasyAuth")]` attribute. This attribute can be set anywhere as long as it uses the right `AuthenticationSchemes`.
@@ -43,12 +43,53 @@ public ActionResult<IEnumerable<string>> Get()
 Add the following line to your `Startup.cs` file.
 
 ```csharp
-using MaximeRouiller.Azure.AppService.EasyAuth
+using MaximeRouiller.Azure.AppService.EasyAuth;
 // ...
 public void ConfigureServices(IServiceCollection services)
 {
     //... rest of the file
     services.AddAuthentication().AddEasyAuthAuthentication((o) => { });
+}
+```
+
+## How to use EasyAuth by default
+
+You may want to use EasyAuth as the default scheme used for authentication.  With this approach it's no longer necessary to provide an `AuthenticationSchemes` with each `Authorize` attribute.  To achieve this you can amend the `Startup.cs` file as follows:
+
+
+```csharp
+using MaximeRouiller.Azure.AppService.EasyAuth;
+// ...
+public void ConfigureServices(IServiceCollection services)
+{
+    //... rest of the file
+    services.AddAuthentication("EasyAuth").AddEasyAuthAuthentication((o) => { });
+}
+```
+
+## How to transform claims
+
+If you have a need to transform the claims that EasyAuth supplies, then there is an `OnClaimsReceived` event available that you can hook into.
+
+For instance, there's a common need to transform the EasyAuth supplied `"roles"` claims into `ClaimsTypes.Role` claims.  This can be acheived as follows:
+
+```csharp
+using MaximeRouiller.Azure.AppService.EasyAuth;
+using System.Linq;
+// ...
+public void ConfigureServices(IServiceCollection services)
+{
+    //... rest of the file
+    services.AddAuthentication("EasyAuth").AddEasyAuthAuthentication((o => o.Events = new EasyAuthEvents {
+        OnClaimsReceived = (claims) => {
+            var mappedRolesClaims = claims
+                .Where(claim => claim.Type == "roles")
+                .Select(claim => new Claim(ClaimTypes.Role, claim.Value))
+                .ToList();
+
+            return Task.FromResult(claims.Concat(mappedRolesClaims));
+        }
+    });
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,17 +80,16 @@ using System.Linq;
 public void ConfigureServices(IServiceCollection services)
 {
     //... rest of the file
-    services.AddAuthentication("EasyAuth").AddEasyAuthAuthentication((o => o.Events = new EasyAuthEvents {
-        OnClaimsReceived = (claims) => {
+    services.AddAuthentication("EasyAuth").AddEasyAuthAuthentication(options =>
+        options.Events.OnClaimsReceived = (claims) => {
             var mappedRolesClaims = claims
                 .Where(claim => claim.Type == "roles")
                 .Select(claim => new Claim(ClaimTypes.Role, claim.Value))
                 .ToList();
 
             return Task.FromResult(claims.Concat(mappedRolesClaims));
-        }
-    });
-}
+        });
+    }
 ```
 
 ## How does it work

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ using System.Linq;
 public void ConfigureServices(IServiceCollection services)
 {
     //... rest of the file
-    services.AddAuthentication("EasyAuth").AddEasyAuthAuthentication(options =>
+    services.AddAuthentication(EasyAuthAuthenticationDefaults.AuthenticationScheme).AddEasyAuthAuthentication(options =>
         options.Events.OnClaimsReceived = (claims) => {
             var mappedRolesClaims = claims
                 .Where(claim => claim.Type == "roles")

--- a/src/EasyAuthAuthenticationBuilderExtensions.cs
+++ b/src/EasyAuthAuthenticationBuilderExtensions.cs
@@ -9,8 +9,8 @@ namespace MaximeRouiller.Azure.AppService.EasyAuth
             this AuthenticationBuilder builder,
             Action<EasyAuthAuthenticationOptions> configure) =>
                 builder.AddScheme<EasyAuthAuthenticationOptions, EasyAuthAuthenticationHandler>(
-                    "EasyAuth",
-                    "EasyAuth",
+                    EasyAuthAuthenticationDefaults.AuthenticationScheme,
+                    EasyAuthAuthenticationDefaults.AuthenticationScheme,
                     configure);
     }
 }

--- a/src/EasyAuthAuthenticationDefaults.cs
+++ b/src/EasyAuthAuthenticationDefaults.cs
@@ -1,0 +1,6 @@
+namespace MaximeRouiller.Azure.AppService.EasyAuth
+{
+    public static class EasyAuthAuthenticationDefaults {
+        public const string AuthenticationScheme = "EasyAuth";
+    }
+}

--- a/src/EasyAuthAuthenticationOptions.cs
+++ b/src/EasyAuthAuthenticationOptions.cs
@@ -4,9 +4,15 @@ namespace MaximeRouiller.Azure.AppService.EasyAuth
 {
     public class EasyAuthAuthenticationOptions : AuthenticationSchemeOptions
     {
+        public new EasyAuthEvents Events
+        {
+            get => (EasyAuthEvents)base.Events;
+            set => base.Events = value;
+        }
+
         public EasyAuthAuthenticationOptions()
         {
-            Events = new object();
+            Events = new EasyAuthEvents();
         }
     }
 }

--- a/src/EasyAuthEvents.cs
+++ b/src/EasyAuthEvents.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace MaximeRouiller.Azure.AppService.EasyAuth
+{
+    public class EasyAuthEvents
+    {
+        /// <summary>
+        /// Invoked after the EasyAuth claims have been unwrapped
+        /// </summary>
+        public Func<IEnumerable<Claim>, Task<IEnumerable<Claim>>> OnClaimsReceived { get; set; } = claims => Task.FromResult(claims);
+    }
+}


### PR DESCRIPTION
Hey @MaximRouiller!

This PR relates to #11 and provides a mechanism by which claims can be transformed.  Rather than just transforming roles claims "in the box", this provides the consumer an `OnClaimsReceived` event which allows them to transform claims prior to them being supplied to the Principal.

To support the use case discussed in #11 of transforming roles claims, a user would do something like the following:

```cs
services.AddAuthentication("EasyAuth").AddEasyAuthAuthentication(options =>
    options.Events.OnClaimsReceived = (claims) => {
        var mappedRolesClaims = claims
            .Where(claim => claim.Type == "roles")
            .Select(claim => new Claim(ClaimTypes.Role, claim.Value))
            .ToList();

        return Task.FromResult(claims.Concat(mappedRolesClaims));
    });
```

I've made the hook `async` to align with the general pattern I see throughout the .NET codebase; see https://github.com/dotnet/aspnetcore/blob/master/src/Security/Authentication/Core/src/Events/RemoteAuthenticationEvents.cs for reference.

I've also added a `EasyAuthAuthenticationDefaults.AuthenticationScheme = "EasyAuth"` const which I thought was "nice to have" - completely not necessary but again aligns nicely with https://github.com/dotnet/aspnetcore/blob/master/src/Security/Authentication/Cookies/src/CookieAuthenticationDefaults.cs#L16

I've tested this with a project of mine deployed to an App Service and it's worked well.  What do you think?
